### PR TITLE
feat(onboarding): Implement referral code capture and application

### DIFF
--- a/actions/gigs/create-gig.ts
+++ b/actions/gigs/create-gig.ts
@@ -12,6 +12,7 @@ type CreateGigInput = {
   gigLocation?: string | { lat?: number; lng?: number; formatted_address?: string; address?: string; [key: string]: any };
   gigDate: string; // YYYY-MM-DD
   gigTime?: string; // HH:mm (24h) or time range like "12:00-14:30"
+  discountCode?: string;
 };
 
 type CreateGigResult = {

--- a/app/(web-client)/user/[userId]/buyer/gigs/new/page.tsx
+++ b/app/(web-client)/user/[userId]/buyer/gigs/new/page.tsx
@@ -1142,6 +1142,13 @@ Make the conversation feel natural and build on what they've already told you.`;
     }
   }
 
+  const getStepTypeForField = (fieldName: string): "input" | "calendar" | "location" | "discountCode" => {
+    if (fieldName === "gigDate") return "calendar";
+    if (fieldName === "gigLocation") return "location";
+    if (fieldName === "discountCode") return "discountCode";
+    return "input";
+  }
+
   // Simple function to handle calendar and location confirmations without AI validation
   async function handlePickerConfirm(stepId: number, inputName: string) {
     const value = formData[inputName];
@@ -1182,14 +1189,7 @@ Make the conversation feel natural and build on what they've already told you.`;
         const contextAwarePrompt = await generateContextAwarePrompt(nextField.name, updatedFormData.gigDescription || '', ai);
         
         // Determine the step type based on the field
-        let stepType: "input" | "calendar" | "location" | "discountCode" = "input";
-        if (nextField.name === "gigDate") {
-          stepType = "calendar";
-        } else if (nextField.name === "gigLocation") {
-          stepType = "location";
-        } else if (nextField.name === "discountCode") {
-           stepType = "discountCode";
-        }
+        const stepType = getStepTypeForField(nextField.name)
         
         const newInputConfig = {
           type: nextField.type as FormInputType,
@@ -1263,15 +1263,7 @@ Make the conversation feel natural and build on what they've already told you.`;
         // Generate context-aware prompt
         const contextAwarePrompt = await generateContextAwarePrompt(nextField.name, updatedFormData.gigDescription || '', ai);
         
-        // Determine the step type based on the field
-        let stepType: "input" | "calendar" | "location" | "discountCode" = "input";
-        if (nextField.name === "gigDate") {
-          stepType = "calendar";
-        } else if (nextField.name === "gigLocation") {
-          stepType = "location";
-        } else if (nextField.name === "discountCode") {
-          stepType = "discountCode";
-        }
+        const stepType = getStepTypeForField(nextField.name)
         
         const newInputConfig = {
           type: nextField.type as FormInputType,
@@ -1453,7 +1445,7 @@ Make the conversation feel natural and build on what they've already told you.`;
         additionalInstructions: formData.additionalInstructions ? String(formData.additionalInstructions) : undefined,
         hourlyRate: formData.hourlyRate ?? 0,
         gigLocation: formData.gigLocation, // Send the original location object to preserve coordinates
-        discountCode: formData.discountCode ? String(formData.discountCode).trim() : undefined,
+        discountCode: formData.discountCode,
         gigDate: String(formData.gigDate || "").slice(0, 10),
         gigTime: formData.gigTime ? String(formData.gigTime) : undefined,
       };
@@ -1980,7 +1972,7 @@ Make the conversation feel natural and build on what they've already told you.`;
                 onConfirm={(code) => {
                   void handleDiscountCodeConfirm(step.id, code);
                 }}
-                role="BUYER"
+                role={"BUYER"}
               />
             );
           }

--- a/app/(web-client)/user/[userId]/buyer/gigs/new/page.tsx
+++ b/app/(web-client)/user/[userId]/buyer/gigs/new/page.tsx
@@ -9,6 +9,7 @@ import MessageBubble from "@/app/components/onboarding/MessageBubble";
 import WorkerCard, { WorkerData } from "@/app/components/onboarding/WorkerCard"; // Import shared WorkerCard and WorkerData
 import LocationPickerBubble from "@/app/components/onboarding/LocationPickerBubble";
 import CalendarPickerBubble from "@/app/components/onboarding/CalendarPickerBubble";
+import DiscountCodeBubble from "@/app/components/onboarding/DiscountCodeBubble";
 
 import Loader from "@/app/components/shared/Loader";
 
@@ -189,6 +190,7 @@ const requiredFields: RequiredField[] = [
   { name: "gigLocation", type: "location", defaultPrompt: "Where is the gig located?" },
   { name: "gigDate", type: "date", defaultPrompt: "What date is the gig?" },
   { name: "gigTime", type: "time", defaultPrompt: "What time does the gig start?" },
+  { name: "discountCode", type: "text", placeholder: "e.g., ABLE20", defaultPrompt: "Great! Just one last thing. Do you have a discount code to apply? 🎟️ If not, no worries!" },
 ];
 
 // Currency note for users
@@ -309,7 +311,7 @@ Respond as a single message, as if you are the bot in a chat.`;
 
 type ChatStep = {
   id: number;
-  type: "bot" | "user" | "input" | "sanitized" | "typing" | "calendar" | "location" | "confirm";
+  type: "bot" | "user" | "input" | "sanitized" | "typing" | "calendar" | "location" | "confirm" | "discountCode";
   content?: string;
   inputConfig?: StepInputConfig;
   isComplete?: boolean;
@@ -519,6 +521,7 @@ export default function OnboardBuyerPage() {
 
   const [formData, setFormData] = useState<Record<string, any>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [discountCode, setDiscountCode] = useState<string | null>();
   const [isConfirming, setIsConfirming] = useState(false);
   const [confirmedSteps, setConfirmedSteps] = useState<Set<number>>(new Set());
   const [currentFocusedInputName, setCurrentFocusedInputName] = useState<string | null>(null);
@@ -854,6 +857,7 @@ Special handling:
 - For dates: Accept any valid date format
 - For location fields: Accept coordinates, addresses, venue names, or any location information
 - For time fields: Accept single times (12:00, 2:30 PM) or time ranges (12:00-14:30, 12:00 PM - 2:30 PM)
+- For discountCode: This is optional. If the user provides a code, sanitize it (e.g., uppercase, remove spaces). If they say "no", "none", "skip", or leave it empty, that is PERFECTLY SUFFICIENT. The sanitizedValue should be an empty string in that case.
 
 If validation passes, respond with:
 - isAppropriate: true
@@ -1178,11 +1182,13 @@ Make the conversation feel natural and build on what they've already told you.`;
         const contextAwarePrompt = await generateContextAwarePrompt(nextField.name, updatedFormData.gigDescription || '', ai);
         
         // Determine the step type based on the field
-        let stepType: "input" | "calendar" | "location" = "input";
+        let stepType: "input" | "calendar" | "location" | "discountCode" = "input";
         if (nextField.name === "gigDate") {
           stepType = "calendar";
         } else if (nextField.name === "gigLocation") {
           stepType = "location";
+        } else if (nextField.name === "discountCode") {
+           stepType = "discountCode";
         }
         
         const newInputConfig = {
@@ -1258,11 +1264,13 @@ Make the conversation feel natural and build on what they've already told you.`;
         const contextAwarePrompt = await generateContextAwarePrompt(nextField.name, updatedFormData.gigDescription || '', ai);
         
         // Determine the step type based on the field
-        let stepType: "input" | "calendar" | "location" = "input";
+        let stepType: "input" | "calendar" | "location" | "discountCode" = "input";
         if (nextField.name === "gigDate") {
           stepType = "calendar";
         } else if (nextField.name === "gigLocation") {
           stepType = "location";
+        } else if (nextField.name === "discountCode") {
+          stepType = "discountCode";
         }
         
         const newInputConfig = {
@@ -1310,6 +1318,30 @@ Make the conversation feel natural and build on what they've already told you.`;
     if (isReformulating) return; // Prevent multiple clicks
     setReformulateField(fieldName);
     setClickedSanitizedButtons(prev => new Set([...prev, `${fieldName}-reformulate`]));
+  };
+
+  useEffect(() => {
+    const codeFromSession = sessionStorage.getItem('referralCode');
+    if (codeFromSession)  setDiscountCode(codeFromSession);
+  }, []);
+
+  const handleDiscountCodeConfirm = async (stepId: number, code: string | null) => {
+    const updatedFormData = { ...formData, discountCode: code || undefined };
+    setFormData(updatedFormData);
+
+    setChatSteps((prev) =>
+      prev.map((step) => (step.id === stepId ? { ...step, isComplete: true } : step))
+    );
+
+    setChatSteps((prev) => [
+      ...prev,
+      {
+        id: Date.now(),
+        type: "bot",
+        content: `Thank you! Here is a summary of your gig:\n${JSON.stringify(updatedFormData, null, 2)}`,
+        isNew: true,
+      },
+    ]);
   };
 
   // After the last input, show a summary message (optionally call AI for summary)
@@ -1421,6 +1453,7 @@ Make the conversation feel natural and build on what they've already told you.`;
         additionalInstructions: formData.additionalInstructions ? String(formData.additionalInstructions) : undefined,
         hourlyRate: formData.hourlyRate ?? 0,
         gigLocation: formData.gigLocation, // Send the original location object to preserve coordinates
+        discountCode: formData.discountCode ? String(formData.discountCode).trim() : undefined,
         gigDate: String(formData.gigDate || "").slice(0, 10),
         gigTime: formData.gigTime ? String(formData.gigTime) : undefined,
       };
@@ -1939,6 +1972,18 @@ Make the conversation feel natural and build on what they've already told you.`;
           }
 
 
+          if (step.type === "discountCode" && !step.isComplete) {
+            return (
+              <DiscountCodeBubble
+                key={key}
+                sessionCode={discountCode ?? null} // Pass the session code from state
+                onConfirm={(code) => {
+                  void handleDiscountCodeConfirm(step.id, code);
+                }}
+                role="BUYER"
+              />
+            );
+          }
           
 
           

--- a/app/components/onboarding/DiscountCodeBubble.module.css
+++ b/app/components/onboarding/DiscountCodeBubble.module.css
@@ -1,0 +1,57 @@
+.promptText {
+  margin: 0 0 12px;
+}
+
+.promptTextLargeMargin {
+  margin: 0 0 16px;
+}
+
+.confirmedMessage {
+  color: #aaa;
+}
+
+.buttonContainer {
+  display: flex;
+  gap: 12px;
+}
+
+.codeInput {
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #444;
+  background: #222;
+  color: #fff;
+  font-size: 15px;
+  margin-bottom: 12px;
+}
+
+.bubbleButton {
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.primary {
+  background: var(--secondary-color);
+  color: #000;
+}
+
+.primary:hover {
+  background: var(--secondary-darker-color);
+}
+
+.secondary {
+  background: transparent;
+  color: var(--secondary-color);
+  border: 1px solid var(--secondary-color);
+}
+
+.secondary:hover {
+  background: var(--secondary-color);
+  color: #000;
+}

--- a/app/components/onboarding/DiscountCodeBubble.tsx
+++ b/app/components/onboarding/DiscountCodeBubble.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import MessageBubble from "./MessageBubble"; 
+
+interface DiscountCodeBubbleProps {
+  sessionCode: string | null;
+  onConfirm: (code: string | null) => void;
+  role: "BUYER" | "WORKER";
+}
+
+const DiscountCodeBubble: React.FC<DiscountCodeBubbleProps> = ({ sessionCode, onConfirm}) => {
+  const [mode, setMode] = useState<'view' | 'edit'>('edit');
+  const [inputValue, setInputValue] = useState("");
+  const [isConfirmed, setIsConfirmed] = useState(false);
+
+  useEffect(() => {
+    if (sessionCode && !isConfirmed) {
+      setMode('view');
+      setInputValue(sessionCode);
+    }
+  }, [sessionCode, isConfirmed]);
+
+  const handleConfirm = (codeToConfirm: string | null) => {
+    if (isConfirmed) return;
+    setIsConfirmed(true);
+    const finalCode = codeToConfirm?.trim().toUpperCase() || null;
+    onConfirm(finalCode);
+  };
+
+  const renderContent = () => {
+    if (isConfirmed) {
+      const confirmedCode = inputValue.trim().toUpperCase();
+      return <div style={{ color: '#aaa' }}>{confirmedCode ? `Discount code "${confirmedCode}" applied.` : "No discount code applied."}</div>;
+    }
+
+    if (mode === 'view' && sessionCode) {
+      return (
+        <div>
+          <p style={{ margin: '0 0 16px' }}>
+            We found a referral code: <strong>{sessionCode}</strong>
+          </p>
+          <div style={{ display: 'flex', gap: 12 }}>
+            <button className="bubble-button primary" onClick={() => handleConfirm(sessionCode)}>
+              Use this code
+            </button>
+            <button className="bubble-button secondary" onClick={() => {
+              setMode('edit');
+              setInputValue('');
+            }}>
+              Enter another
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <p style={{ margin: '0 0 12px' }}>Do you have a different discount code? Enter it below or skip.</p>
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          placeholder="e.g., ABLE20"
+          style={{
+            width: '100%',
+            padding: '10px',
+            borderRadius: '8px',
+            border: '1px solid #444',
+            background: '#222',
+            color: '#fff',
+            fontSize: '15px',
+            marginBottom: '12px'
+          }}
+        />
+        <div style={{ display: 'flex', gap: 12 }}>
+          <button className="bubble-button primary" onClick={() => handleConfirm(inputValue)}>
+            Apply Code
+          </button>
+          <button className="bubble-button secondary" onClick={() => handleConfirm(null)}>
+            Skip
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <style>{`
+        /* ... styles are unchanged ... */
+        .bubble-button {
+          border: none;
+          border-radius: 8px;
+          padding: 8px 16px;
+          font-weight: 600;
+          font-size: 14px;
+          cursor: pointer;
+          transition: all 0.2s;
+        }
+        .bubble-button.primary {
+          background: var(--secondary-color);
+          color: #000;
+        }
+        .bubble-button.primary:hover {
+          background: var(--secondary-darker-color);
+        }
+        .bubble-button.secondary {
+          background: transparent;
+          color: var(--secondary-color);
+          border: 1px solid var(--secondary-color);
+        }
+         .bubble-button.secondary:hover {
+          background: var(--secondary-color);
+          color: #000;
+        }
+      `}</style>
+      <MessageBubble
+        text={renderContent()}
+        senderType="bot"
+        role={"BUYER"}
+        showAvatar={true}
+      />
+    </>
+  );
+};
+
+export default DiscountCodeBubble;

--- a/app/components/onboarding/DiscountCodeBubble.tsx
+++ b/app/components/onboarding/DiscountCodeBubble.tsx
@@ -2,14 +2,15 @@
 
 import React, { useState, useEffect } from "react";
 import MessageBubble from "./MessageBubble"; 
+import styles from "./DiscountCodeBubble.module.css";
 
 interface DiscountCodeBubbleProps {
   sessionCode: string | null;
   onConfirm: (code: string | null) => void;
-  role: "BUYER" | "WORKER";
+  role: "BUYER" | "GIG_WORKER";
 }
 
-const DiscountCodeBubble: React.FC<DiscountCodeBubbleProps> = ({ sessionCode, onConfirm}) => {
+const DiscountCodeBubble: React.FC<DiscountCodeBubbleProps> = ({ sessionCode, onConfirm, role}) => {
   const [mode, setMode] = useState<'view' | 'edit'>('edit');
   const [inputValue, setInputValue] = useState("");
   const [isConfirmed, setIsConfirmed] = useState(false);
@@ -31,20 +32,20 @@ const DiscountCodeBubble: React.FC<DiscountCodeBubbleProps> = ({ sessionCode, on
   const renderContent = () => {
     if (isConfirmed) {
       const confirmedCode = inputValue.trim().toUpperCase();
-      return <div style={{ color: '#aaa' }}>{confirmedCode ? `Discount code "${confirmedCode}" applied.` : "No discount code applied."}</div>;
+      return <div className={styles.confirmedMessage}>{confirmedCode ? `Discount code "${confirmedCode}" applied.` : "No discount code applied."}</div>;
     }
 
     if (mode === 'view' && sessionCode) {
       return (
         <div>
-          <p style={{ margin: '0 0 16px' }}>
+          <p className={styles.promptTextLargeMargin}>
             We found a referral code: <strong>{sessionCode}</strong>
           </p>
-          <div style={{ display: 'flex', gap: 12 }}>
-            <button className="bubble-button primary" onClick={() => handleConfirm(sessionCode)}>
+          <div className={styles.buttonContainer}>
+            <button className={`${styles.bubbleButton} ${styles.primary}`} onClick={() => handleConfirm(sessionCode)}>
               Use this code
             </button>
-            <button className="bubble-button secondary" onClick={() => {
+            <button className={`${styles.bubbleButton} ${styles.secondary}`} onClick={() => {
               setMode('edit');
               setInputValue('');
             }}>
@@ -57,28 +58,19 @@ const DiscountCodeBubble: React.FC<DiscountCodeBubbleProps> = ({ sessionCode, on
 
     return (
       <div>
-        <p style={{ margin: '0 0 12px' }}>Do you have a different discount code? Enter it below or skip.</p>
+        <p className={styles.promptText}>Do you have a different discount code? Enter it below or skip.</p>
         <input
           type="text"
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           placeholder="e.g., ABLE20"
-          style={{
-            width: '100%',
-            padding: '10px',
-            borderRadius: '8px',
-            border: '1px solid #444',
-            background: '#222',
-            color: '#fff',
-            fontSize: '15px',
-            marginBottom: '12px'
-          }}
+          className={styles.codeInput}
         />
-        <div style={{ display: 'flex', gap: 12 }}>
-          <button className="bubble-button primary" onClick={() => handleConfirm(inputValue)}>
+        <div className={styles.buttonContainer}>
+          <button className={`${styles.bubbleButton} ${styles.primary}`} onClick={() => handleConfirm(inputValue)}>
             Apply Code
           </button>
-          <button className="bubble-button secondary" onClick={() => handleConfirm(null)}>
+          <button className={`${styles.bubbleButton} ${styles.secondary}`} onClick={() => handleConfirm(null)}>
             Skip
           </button>
         </div>
@@ -87,42 +79,12 @@ const DiscountCodeBubble: React.FC<DiscountCodeBubbleProps> = ({ sessionCode, on
   };
 
   return (
-    <>
-      <style>{`
-        /* ... styles are unchanged ... */
-        .bubble-button {
-          border: none;
-          border-radius: 8px;
-          padding: 8px 16px;
-          font-weight: 600;
-          font-size: 14px;
-          cursor: pointer;
-          transition: all 0.2s;
-        }
-        .bubble-button.primary {
-          background: var(--secondary-color);
-          color: #000;
-        }
-        .bubble-button.primary:hover {
-          background: var(--secondary-darker-color);
-        }
-        .bubble-button.secondary {
-          background: transparent;
-          color: var(--secondary-color);
-          border: 1px solid var(--secondary-color);
-        }
-         .bubble-button.secondary:hover {
-          background: var(--secondary-color);
-          color: #000;
-        }
-      `}</style>
-      <MessageBubble
-        text={renderContent()}
-        senderType="bot"
-        role={"BUYER"}
-        showAvatar={true}
-      />
-    </>
+    <MessageBubble
+      text={renderContent()}
+      senderType="bot"
+      role={role}
+      showAvatar={true}
+    />
   );
 };
 

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -23,6 +23,16 @@ export default function SignInPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user, loadingAuth]);
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const referralCode = params.get('code');
+
+    if (referralCode) {
+      sessionStorage.setItem('referralCode', referralCode);
+      toast.info(`Referral code "${referralCode}" has been saved!`);
+    }
+  }, []);
+
   const handleCloseError = () => {
     setError(null);
   };


### PR DESCRIPTION
This commit introduces the user-facing part of the referral code feature, allowing a new buyer to use a discount code during the onboarding process.

- Captures the `code` URL parameter on the sign-in page and stores it in sessionStorage.
- Adds a new `DiscountCodeBubble` component to display the session code or allow for manual entry.
- Integrates the component as the final step in the buyer onboarding chat before the gig summary.
- Updates the chat flow logic in `OnboardBuyerPage` to correctly handle  discount code step.