### PR TITLE
chore: clean up unused imports, variables, and dependencies across actions and web-client components

### DIFF
--- a/actions/events/get-calendar-events.ts
+++ b/actions/events/get-calendar-events.ts
@@ -201,7 +201,7 @@ async function getBuyerCalendarEvents(user: typeof UsersTable.$inferSelect): Pro
 export async function getCalendarEvents({
   userId,
   role,
-  isViewQA,
+  // isViewQA,
 }: {
   userId: string;
   role?: "buyer" | "worker";

--- a/actions/gigs/get-gig-details.ts
+++ b/actions/gigs/get-gig-details.ts
@@ -135,9 +135,9 @@ function extractLocationAggressively(obj: any): string | null {
   
   return null;
 }
-
-// Helper function to parse location from gig data
-function parseGigLocation(gig: any): string {
+/**
+ * Helper function to parse location from gig data
+  function parseGigLocation(gig: any): string {
   // Try to extract location from addressJson first (prioritize formatted addresses)
   if (gig.addressJson) {
     if (typeof gig.addressJson === 'string') {
@@ -188,6 +188,9 @@ function parseGigLocation(gig: any): string {
   // Return fallback location if no valid location found
   return 'Location details available';
 }
+ */
+
+
 
 export async function getGigDetails({
   gigId,

--- a/actions/gigs/get-worker-offers.ts
+++ b/actions/gigs/get-worker-offers.ts
@@ -2,8 +2,8 @@
 
 import { db } from "@/lib/drizzle/db";
 import { eq } from "drizzle-orm";
-import { gigStatusEnum, UsersTable, GigsTable, GigWorkerProfilesTable } from "@/lib/drizzle/schema";
-import { isWorkerWithinDistance, parseCoordinates, calculateDistance } from "@/lib/utils/distance";
+import { UsersTable, GigsTable } from "@/lib/drizzle/schema";
+import { parseCoordinates, calculateDistance } from "@/lib/utils/distance";
 
 // Constants
 const DEFAULT_GIG_SEARCH_RADIUS_KM = 30;

--- a/actions/gigs/search-workers-for-delegation.ts
+++ b/actions/gigs/search-workers-for-delegation.ts
@@ -2,10 +2,10 @@
 
 import { db } from "@/lib/drizzle/db";
 import { UsersTable, GigWorkerProfilesTable, SkillsTable, GigsTable, WorkerAvailabilityTable } from "@/lib/drizzle/schema";
-import { eq, and, ne, like, or, gte, lte, sql } from "drizzle-orm";
+import { eq, and, ne, like, or } from "drizzle-orm";
 import { isUserAuthenticated } from "@/lib/user.server";
 import { ERROR_CODES } from "@/lib/responses/errors";
-import { isWorkerWithinDistance, calculateDistance, parseCoordinates } from "@/lib/utils/distance";
+import { calculateDistance, parseCoordinates } from "@/lib/utils/distance";
 
 // Constants
 const DELEGATION_SEARCH_RADIUS_KM = 30;

--- a/actions/user/edit-worker-profile.ts
+++ b/actions/user/edit-worker-profile.ts
@@ -200,7 +200,7 @@ export const addEquipmentAction = async (
   name: string,
   token?: string,
   description?: string,
-  documentUrl?: string
+  // documentUrl?: string
 ) => {
   try {
     if (!token) {

--- a/app/(web-client)/select-role/page.tsx
+++ b/app/(web-client)/select-role/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import Logo from "@/app/components/brand/Logo";
 import ActionButton from "./ActionButton";

--- a/app/(web-client)/user/[userId]/buyer/gigs/[gigId]/noReply/page.tsx
+++ b/app/(web-client)/user/[userId]/buyer/gigs/[gigId]/noReply/page.tsx
@@ -2,7 +2,7 @@
 
 import styles from './NoReply.module.css'
 import RehireWorkerCard from '@/app/components/buyer/RehireWorkerCard';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -92,7 +92,7 @@ const suggestedWorkers = [
 ];
 
   const { userId, gigId } = useParams();
-  const router = useRouter();
+  // const router = useRouter();
 
 useEffect(() => {
     const fetchData = async (buyerUserId: string, gigId: string) => {

--- a/app/(web-client)/user/[userId]/buyer/gigs/[gigId]/rehire/RehireView.tsx
+++ b/app/(web-client)/user/[userId]/buyer/gigs/[gigId]/rehire/RehireView.tsx
@@ -3,7 +3,7 @@ import ChatBotLayout from "@/app/components/onboarding/ChatBotLayout";
 import MessageBubble from "@/app/components/onboarding/MessageBubble";
 import RehireWorkerCard from "@/app/components/buyer/RehireWorkerCard";
 import Link from "next/link";
-import { Home, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import styles from "./RehirePage.module.css";
 import type { OriginalGigInfo, RehireWorkerData } from "./RehireContainer";
 import Image from "next/image";

--- a/app/components/shared/PiChart.tsx
+++ b/app/components/shared/PiChart.tsx
@@ -111,14 +111,12 @@ export default function PieChartComponent({
   const [chartHeight, setChartHeight] = useState(220);
   const [tooltipActive, setTooltipActive] = useState(false);
   const chartRef = useRef<HTMLDivElement>(null);
+  const dependencyValue = typeof window !== "undefined" ? window.innerWidth : 1024;
   const outerRadius = useMemo(() => {
-    if (typeof window !== "undefined") {
-      // if (window.innerWidth < 400) return 70;
-      if (window.innerWidth < 500) return 70;
-      if (window.innerWidth < 768) return 90;
-    }
+    if (dependencyValue < 500) return 70;
+    if (dependencyValue < 768) return 90;
     return 110;
-  }, [typeof window !== "undefined" ? window.innerWidth : 1024]);
+  }, [dependencyValue]);
 
   useEffect(() => {
     const handleResize = () => {

--- a/utils/ProtectedRoute.tsx
+++ b/utils/ProtectedRoute.tsx
@@ -13,7 +13,7 @@ export const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
     if (!loading && !user?.claims.role) {
       router.push("/");
     }
-  }, [loading, user?.claims]);
+  }, [loading, user?.claims, router]);
 
   if (loading || !user) {
     return (


### PR DESCRIPTION
### Summary
Removed unused variables, imports, and adjusted dependencies across actions, web-client pages, and shared components to improve readability and maintainability.

### Changes
- `get-calendar-events.ts`: commented out unused `isViewQA` prop.
- `get-gig-details.ts`: commented out unused `parseGigLocation` helper.
- `get-worker-offers.ts`: removed unused `gigStatusEnum` and `isWorkerWithinDistance`.
- `search-workers-for-delegation.ts`: removed unused operators (`gte`, `lte`, `sql`) and distance helpers.
- `edit-worker-profile.ts`: commented out unused `documentUrl` param.
- `select-role/page.tsx`: removed unused `useEffect`.
- `noReply/page.tsx`: removed unused `useRouter`.
- `RehireView.tsx`: removed unused `Home` icon.
- `PiChart.tsx`: refactored `outerRadius` logic to use `dependencyValue` instead of `window.innerWidth`.
- `ProtectedRoute.tsx`: added `router` to dependency array in `useEffect`.

### Motivation
These cleanups reduce warnings, unused code, and potential linting errors, keeping the codebase easier to maintain.

### Notes
No functional or behavioral changes were introduced — this PR only removes unused code and adjusts minor dependencies.
