### PR TITLE
fix: show message when data is empty in payments and empty graph

### DIFF
--- a/actions/payments/get-buyer-payments.ts
+++ b/actions/payments/get-buyer-payments.ts
@@ -84,7 +84,6 @@ export async function getBuyerPayments(buyerId: string, filters: FilterState): P
       .where(and(eq(PaymentsTable.payerUserId, user.id), conditions.length > 0 ? and(...conditions) : undefined))
       .orderBy(desc(PaymentsTable.createdAt));
 
-    console.log({userPayments})
     if (!userPayments) {
       return {
         success: false,

--- a/app/(web-client)/user/[userId]/buyer/payments/page.tsx
+++ b/app/(web-client)/user/[userId]/buyer/payments/page.tsx
@@ -127,7 +127,6 @@ export default function BuyerPaymentsPage() {
   if (isLoading || (!user && !isLoading) || (authUserId && authUserId !== pageUserId)) {
     return <div className={styles.loadingContainer}><Loader2 className="animate-spin" size={32} /> Loading...</div>;
   }
-  console.log({chartData})
 
   return (
     <div className={styles.container}>
@@ -289,7 +288,7 @@ export default function BuyerPaymentsPage() {
 
         <div className={styles.barChartContainer}>
           {!isLoadingPayments &&
-            <BarChartComponent data={chartData} emptyMessage="You don't have payments yet 2"/>
+            <BarChartComponent data={chartData} emptyMessage="You don't have payments yet"/>
           }
         </div>
       </div>

--- a/app/(web-client)/user/[userId]/buyer/payments/page.tsx
+++ b/app/(web-client)/user/[userId]/buyer/payments/page.tsx
@@ -127,6 +127,7 @@ export default function BuyerPaymentsPage() {
   if (isLoading || (!user && !isLoading) || (authUserId && authUserId !== pageUserId)) {
     return <div className={styles.loadingContainer}><Loader2 className="animate-spin" size={32} /> Loading...</div>;
   }
+  console.log({chartData})
 
   return (
     <div className={styles.container}>
@@ -288,7 +289,7 @@ export default function BuyerPaymentsPage() {
 
         <div className={styles.barChartContainer}>
           {!isLoadingPayments &&
-            <BarChartComponent data={chartData} />
+            <BarChartComponent data={chartData} emptyMessage="You don't have payments yet 2"/>
           }
         </div>
       </div>

--- a/app/(web-client)/user/[userId]/buyer/profile/page.tsx
+++ b/app/(web-client)/user/[userId]/buyer/profile/page.tsx
@@ -291,9 +291,8 @@ export default function BuyerProfilePage() {
                 id: 1,
                 icon: ThumbsUp,
                 value: dashboardData?.responseRateInternal || 0,
-                label: `Would work with ${
-                  user?.displayName?.split(" ")?.[0] ?? ""
-                } again`,
+                label: `Would work with ${user?.displayName?.split(" ")?.[0] ?? ""
+                  } again`,
                 iconColor: "#7eeef9",
               }}
             />
@@ -338,7 +337,7 @@ export default function BuyerProfilePage() {
           <h2 className={styles.sectionTitle}>Workforce Analytics</h2>
           <div className={styles.analyticsChartsContainer}>
             <PieChartComponent skills={dashboardData?.skills} />
-            <BarChartComponent data={dashboardData?.totalPayments} />
+            <BarChartComponent data={dashboardData?.totalPayments || []} emptyMessage="You don't have payments yet" />
           </div>
         </section>
 

--- a/app/(web-client)/user/[userId]/worker/earnings/page.tsx
+++ b/app/(web-client)/user/[userId]/worker/earnings/page.tsx
@@ -29,7 +29,6 @@ async function fetchWorkerEarnings(userId: string, filters: FilterState): Promis
   return allEarnings;
 }
 
-
 // Mock chart data (aggregate by month for example)
 const getEarningsChartData = (earnings: WorkerEarning[]) => {
   const monthlyTotals: { [key: string]: number } = {};
@@ -210,7 +209,7 @@ export default function WorkerEarningsPage() {
         )}
         <div className={styles.barChartContainer}>
           {!isLoadingEarnings &&
-            <BarChartComponent data={chartData} />
+            <BarChartComponent data={chartData} emptyMessage="You don't have earnings yet" />
           }
         </div>
         {/* 

--- a/app/components/shared/BarChart.tsx
+++ b/app/components/shared/BarChart.tsx
@@ -38,7 +38,7 @@ const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?:
   return null;
 };
 
-export default function BarChartComponent({ data }: { data?: { name: string; total: number }[] }) {
+export default function BarChartComponent({ data, emptyMessage }: { data?: { name: string; total: number }[], emptyMessage: string }) {
   const [chartHeight, setChartHeight] = useState(220);
 
   const isWindowDefined = typeof window !== 'undefined';
@@ -72,28 +72,35 @@ export default function BarChartComponent({ data }: { data?: { name: string; tot
 
   return (
     <ResponsiveContainer width="100%" height={chartHeight} minHeight={120}>
-      <BarChart data={data} margin={{ top: 10, right: 10, left: 10, bottom: 30 }}>
-        <XAxis
-          dataKey="name"
-          type="category"
-          tick={{ fontSize, fill: '#fff' }}
-          axisLine={{ stroke: '#fff' }}
+      {data && data?.length > 0 ?
+        <BarChart data={data} margin={{ top: 10, right: 10, left: 10, bottom: 30 }}>
+          <XAxis
+            dataKey="name"
+            type="category"
+            tick={{ fontSize, fill: '#fff' }}
+            axisLine={{ stroke: '#fff' }}
+          >
+            <Label value="Quarter" offset={-10} position="insideBottom" style={{ fill: '#fff', fontSize: fontSize + 1 }} />
+          </XAxis>
+          <YAxis
+            padding={{ top: 15 }}
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "#fff", fontSize: fontSize + 1 }}
+            tickFormatter={(value) => `£${value}`}
+          />
+          <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(250,204,21,0.08)' }} />
+          <CartesianGrid stroke="#fff" strokeDasharray="5" />
+          <Bar dataKey="total" stackId="total" fill="var(--success-color)" radius={[4, 4, 0, 0]}>
+            <LabelList dataKey="total" position="top" style={{ fill: '#facc15', fontSize: fontSize - 1, fontWeight: 600 }} />
+          </Bar>
+        </BarChart> :
+        <div
+          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%'}}
         >
-          <Label value="Quarter" offset={-10} position="insideBottom" style={{ fill: '#fff', fontSize: fontSize + 1 }} />
-        </XAxis>
-        <YAxis
-          padding={{ top: 15 }}
-          axisLine={false}
-          tickLine={false}
-          tick={{ fill: "#fff", fontSize: fontSize + 1 }}
-          tickFormatter={(value) => `£${value}`}
-        />
-        <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(250,204,21,0.08)' }} />
-        <CartesianGrid stroke="#fff" strokeDasharray="5" />
-        <Bar dataKey="total" stackId="total" fill="var(--success-color)" radius={[4, 4, 0, 0]}>
-          <LabelList dataKey="total" position="top" style={{ fill: '#facc15', fontSize: fontSize - 1, fontWeight: 600 }} />
-        </Bar>
-      </BarChart>
+          {emptyMessage}
+        </div>
+      }
     </ResponsiveContainer>
   );
 }

--- a/app/components/shared/BarChart.tsx
+++ b/app/components/shared/BarChart.tsx
@@ -38,7 +38,7 @@ const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?:
   return null;
 };
 
-export default function BarChartComponent({ data, emptyMessage }: { data?: { name: string; total: number }[], emptyMessage: string }) {
+export default function BarChartComponent({ data, emptyMessage }: { data: { name: string; total: number }[], emptyMessage: string }) {
   const [chartHeight, setChartHeight] = useState(220);
 
   const isWindowDefined = typeof window !== 'undefined';
@@ -72,7 +72,7 @@ export default function BarChartComponent({ data, emptyMessage }: { data?: { nam
 
   return (
     <ResponsiveContainer width="100%" height={chartHeight} minHeight={120}>
-      {data && data?.length > 0 ?
+      {data?.length > 0 ?
         <BarChart data={data} margin={{ top: 10, right: 10, left: 10, bottom: 30 }}>
           <XAxis
             dataKey="name"


### PR DESCRIPTION
## Summary
Added a feedback message in the graph container when the chart data is empty

## Changes Made
- Added message to show when data is empty on payments or earnings view 

## Benefits
-  Show feedback when the data to the graph is empty